### PR TITLE
Renamed `projectId` to `productId` in getLockedProductPositionRows  to match with actual API response

### DIFF
--- a/src/modules/restful/simpleEarn/types.ts
+++ b/src/modules/restful/simpleEarn/types.ts
@@ -167,7 +167,7 @@ export interface getLockedProductPositionResponse {
 
 interface getLockedProductPositionRows {
     positionId: string;
-    projectId: string;
+    productId: string;
     asset: string;
     amount: string;
     purchaseTime: string;


### PR DESCRIPTION
<img width="841" alt="image" src="https://github.com/binance/binance-connector-typescript/assets/1146708/3101fadd-b611-4a41-a361-b7d8555c8658">
