### PR TITLE
fix: property quoteAsset in queryUserWalletBalanceOptions

### DIFF
--- a/src/modules/restful/wallet/types.ts
+++ b/src/modules/restful/wallet/types.ts
@@ -332,6 +332,7 @@ export interface assetDetailResponse {
 
 export interface queryUserWalletBalanceOptions {
     recvWindow?: number;
+    quoteAsset?: string;
 }
 
 export interface queryUserWalletBalanceResponse {


### PR DESCRIPTION
According to [docs](https://developers.binance.com/docs/wallet/asset/query-user-wallet-balance), interface `queryUserWalletBalanceOptions` lost a property `quoteAsset`